### PR TITLE
recommend removing verbose flag and text referring to it

### DIFF
--- a/articles/application-gateway/application-gateway-create-probe-ps.md
+++ b/articles/application-gateway/application-gateway-create-probe-ps.md
@@ -242,6 +242,6 @@ Update the back-end pool setting to remove the probe and time-out setting by usi
 
 ### Step 4
 
-Save the configuration to the application gateway by using **Set-AzureRmApplicationGateway**. While verbose mode is not necessary it is a good idea to use it for such operation's progress tracking.
+Save the configuration to the application gateway by using **Set-AzureRmApplicationGateway**.
 
-	Set-AzureRmApplicationGateway -ApplicationGateway $getgw -verbose
+	Set-AzureRmApplicationGateway -ApplicationGateway $getgw


### PR DESCRIPTION
@AlekseiPolkovnikov Thanks for the contribution. I remember you found another issue like this.  Do you mind if we remove the text and just remove the verbose flag, it doesn't provide any extra details with the cmdlet in reference.  Thanks Again

-verbose does nothing for set-azurermapplicationgateway, recommend removing the -verbose flag from the code example and any reference to it in the text.
